### PR TITLE
View deployment configuration

### DIFF
--- a/k8s/02_deployment_app.yaml
+++ b/k8s/02_deployment_app.yaml
@@ -1,1 +1,33 @@
-placeholder
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-app
+  labels:
+    app: demo-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: demo-app
+  template:
+    metadata:
+      labels:
+        app: demo-app
+    spec:
+      containers:
+      - name: demo-app
+        image: demo-app:latest
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-service
+spec:
+  selector:
+    app: demo-app
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
This PR shows the Kubernetes deployment and service configuration from the `k8s/02_deployment_app.yaml` file. This configuration defines a deployment with 3 replicas of the demo-app container and a ClusterIP service that exposes it on port 80.